### PR TITLE
Move the header to a sidebar

### DIFF
--- a/sandbox/App.tsx
+++ b/sandbox/App.tsx
@@ -32,10 +32,12 @@ const Home = () => {
       <main className={`theme-${network} theme-${theme}`}>
         <div className="sidenav">
           <h5>
-            <button onClick={() => setNetwork("polkadot")}>Polkadot</button> |{" "}
-            <button onClick={() => setNetwork("kusama")}>Kusama</button> |{" "}
-            <button onClick={() => setNetwork("westend")}>Westend</button>.{" "}
-            Theme: <button onClick={() => setTheme("light")}>Light</button> |{" "}
+            <p>Network:</p>
+            <button onClick={() => setNetwork("polkadot")}>Polkadot</button>
+            <button onClick={() => setNetwork("kusama")}>Kusama</button>
+            <button onClick={() => setNetwork("westend")}>Westend</button>
+            <p>Theme:</p>
+            <button onClick={() => setTheme("light")}>Light</button>
             <button onClick={() => setTheme("dark")}>Dark</button>
           </h5>
         </div>

--- a/sandbox/App.tsx
+++ b/sandbox/App.tsx
@@ -2,20 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from "react";
-import { ButtonPrimary } from "../lib/buttons/ButtonPrimary";
-import { ButtonMono } from "../lib/buttons/ButtonMono";
-import { ButtonMonoInvert } from "../lib/buttons/ButtonMonoInvert";
-import { ButtonSecondary } from "../lib/buttons/ButtonSecondary";
-import { ButtonInvert } from "../lib/buttons/ButtonInvert";
-import { ButtonInvertRounded } from "../lib/buttons/ButtonInvertRounded";
-import { ButtonText } from "../lib/buttons/ButtonText";
-import { ButtonSubmit } from "../lib/buttons/ButtonSubmit";
-import { ButtonHelp } from "../lib/buttons/ButtonHelp";
-import { faUser } from "@fortawesome/free-solid-svg-icons";
-import {
-  faArrowAltCircleUp,
-  faUser as faUserReg,
-} from "@fortawesome/free-regular-svg-icons";
+import { Buttons } from "./components";
+
+const getComponent = (component: string) => {
+  switch (component) {
+    case "buttons":
+      return <Buttons />;
+    default:
+      return <Buttons />;
+  }
+};
 
 /*
  * Sandbox page for component tests and class inclusion.
@@ -26,6 +22,9 @@ const Home = () => {
 
   // store the current network
   const [network, setNetwork] = useState<string>("polkadot");
+
+  // store the visible Component
+  const [component, setComponent] = useState<string>("buttons");
 
   return (
     <>
@@ -40,152 +39,12 @@ const Home = () => {
             <button onClick={() => setTheme("light")}>Light</button>
             <button onClick={() => setTheme("dark")}>Dark</button>
           </h5>
+          <h5>
+            <p>Component:</p>
+            <button onClick={() => setComponent("buttons")}>Buttons</button>
+          </h5>
         </div>
-        <div className="body">
-          <h4>Button Primary</h4>
-
-          <div className="row">
-            <ButtonPrimary text="Button" iconLeft={faUser} marginRight />
-            <ButtonPrimary
-              text="Button"
-              iconLeft={faUser}
-              marginRight
-              colorSecondary
-            />
-            <ButtonPrimary
-              text="Button"
-              iconLeft={faUser}
-              iconRight={faUser}
-              lg
-              marginRight
-            />
-            <ButtonPrimary text="Button" lg disabled />
-          </div>
-
-          <h4>Button Secondary</h4>
-          <div className="row">
-            <ButtonSecondary text="Button" marginRight />
-            <ButtonSecondary text="Button" iconLeft={faUser} marginRight />
-            <ButtonSecondary text="Button" iconRight={faUser} marginRight />
-            <ButtonSecondary
-              lg
-              text="Button"
-              iconLeft={faUser}
-              iconRight={faUser}
-              marginRight
-            />
-            <ButtonSecondary lg text="Button" disabled />
-          </div>
-
-          <h4>Button Mono</h4>
-          <div className="row">
-            <ButtonMono text="Button" marginRight />
-            <ButtonMono text="Button" iconLeft={faUser} marginRight />
-            <ButtonMono text="Button" iconRight={faUser} marginRight />
-            <ButtonMono
-              lg
-              text="Button"
-              iconLeft={faUser}
-              iconRight={faUser}
-              marginRight
-            />
-            <ButtonMono lg text="Button" disabled />
-          </div>
-
-          <h4>Button Mono Invert</h4>
-          <div className="row">
-            <ButtonMonoInvert text="Button" marginRight />
-            <ButtonMonoInvert text="Button" iconLeft={faUser} marginRight />
-            <ButtonMonoInvert text="Button" iconRight={faUser} marginRight />
-            <ButtonMonoInvert
-              lg
-              text="Button"
-              iconLeft={faUser}
-              iconRight={faUser}
-              marginRight
-            />
-            <ButtonMonoInvert lg text="Button" disabled />
-          </div>
-
-          <h4>Button Invert</h4>
-          <div className="row">
-            <ButtonInvert text="Button" marginRight />
-            <ButtonInvert text="Button" iconLeft={faUserReg} marginRight />
-            <ButtonInvert text="Button" iconRight={faUserReg} marginRight />
-            <ButtonInvert
-              text="Button"
-              iconLeft={faUserReg}
-              iconRight={faUserReg}
-              marginRight
-            />
-            <ButtonInvert text="Button" disabled />
-          </div>
-
-          <h4>Button Invert Rounded</h4>
-          <div className="row">
-            <ButtonInvertRounded text="Button" marginRight />
-            <ButtonInvertRounded
-              text="Button"
-              iconLeft={faUserReg}
-              marginRight
-            />
-            <ButtonInvertRounded
-              text="Button"
-              iconRight={faUserReg}
-              marginRight
-            />
-            <ButtonInvertRounded
-              lg
-              text="Button"
-              iconLeft={faUserReg}
-              iconRight={faUserReg}
-              marginRight
-            />
-            <ButtonInvertRounded lg text="Button" disabled />
-          </div>
-
-          <h4>Button Text</h4>
-          <div className="row">
-            <ButtonText text="Button" marginRight />
-            <ButtonText text="Button" iconLeft={faUserReg} marginRight />
-            <ButtonText text="Button" iconRight={faUserReg} marginRight />
-            <ButtonText
-              text="Button"
-              iconLeft={faUserReg}
-              iconRight={faUserReg}
-              marginRight
-            />
-            <ButtonText text="Button" disabled />
-          </div>
-
-          <h4>Button Submit</h4>
-          <div className="row">
-            <ButtonSubmit text="Button" marginRight />
-            <ButtonSubmit
-              text="Button"
-              iconLeft={faArrowAltCircleUp}
-              marginRight
-              colorSecondary
-            />
-            <ButtonSubmit
-              text="Button"
-              iconRight={faArrowAltCircleUp}
-              marginRight
-            />
-            <ButtonSubmit
-              text="Button"
-              iconLeft={faArrowAltCircleUp}
-              iconRight={faArrowAltCircleUp}
-              marginRight
-            />
-            <ButtonSubmit text="Button" disabled />
-          </div>
-          <h4>Button Help</h4>
-          <div className="row">
-            <ButtonHelp marginRight />
-            <ButtonHelp backgroundSecondary />
-          </div>
-        </div>
+        <div className="body">{getComponent(component)}</div>
       </main>
     </>
   );

--- a/sandbox/App.tsx
+++ b/sandbox/App.tsx
@@ -30,7 +30,7 @@ const Home = () => {
   return (
     <>
       <main className={`theme-${network} theme-${theme}`}>
-        <div className="header">
+        <div className="sidenav">
           <h5>
             <button onClick={() => setNetwork("polkadot")}>Polkadot</button> |{" "}
             <button onClick={() => setNetwork("kusama")}>Kusama</button> |{" "}

--- a/sandbox/App.tsx
+++ b/sandbox/App.tsx
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from "react";
-import { Buttons } from "./components";
+import { Buttons } from "./components/Buttons";
 
 const getComponent = (component: string) => {
   switch (component) {
-    case "buttons":
-      return <Buttons />;
     default:
       return <Buttons />;
   }
@@ -29,20 +27,52 @@ const Home = () => {
   return (
     <>
       <main className={`theme-${network} theme-${theme}`}>
-        <div className="sidenav">
-          <h5>
-            <p>Network:</p>
-            <button onClick={() => setNetwork("polkadot")}>Polkadot</button>
-            <button onClick={() => setNetwork("kusama")}>Kusama</button>
-            <button onClick={() => setNetwork("westend")}>Westend</button>
-            <p>Theme:</p>
-            <button onClick={() => setTheme("light")}>Light</button>
-            <button onClick={() => setTheme("dark")}>Dark</button>
-          </h5>
-          <h5>
-            <p>Component:</p>
-            <button onClick={() => setComponent("buttons")}>Buttons</button>
-          </h5>
+        <div className="nav">
+          <section>
+            <h5>Network</h5>
+            <button
+              className={network === "polkadot" ? "selected" : undefined}
+              onClick={() => setNetwork("polkadot")}
+            >
+              Polkadot
+            </button>
+            <button
+              className={network === "kusama" ? "selected" : undefined}
+              onClick={() => setNetwork("kusama")}
+            >
+              Kusama
+            </button>
+            <button
+              className={network === "westend" ? "selected" : undefined}
+              onClick={() => setNetwork("westend")}
+            >
+              Westend
+            </button>
+          </section>
+          <section>
+            <h5>Theme</h5>
+            <button
+              className={theme === "light" ? "selected" : undefined}
+              onClick={() => setTheme("light")}
+            >
+              Light
+            </button>
+            <button
+              className={theme === "dark" ? "selected" : undefined}
+              onClick={() => setTheme("dark")}
+            >
+              Dark
+            </button>
+          </section>
+          <section>
+            <h5>Category</h5>
+            <button
+              className="selected"
+              onClick={() => setComponent("buttons")}
+            >
+              Buttons
+            </button>
+          </section>
         </div>
         <div className="body">{getComponent(component)}</div>
       </main>

--- a/sandbox/components/Buttons.tsx
+++ b/sandbox/components/Buttons.tsx
@@ -1,5 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
+
 import React from "react";
 import { ButtonPrimary } from "../../lib/buttons/ButtonPrimary";
 import { ButtonMono } from "../../lib/buttons/ButtonMono";

--- a/sandbox/components/Buttons.tsx
+++ b/sandbox/components/Buttons.tsx
@@ -1,0 +1,153 @@
+// Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+import React from "react";
+import { ButtonPrimary } from "../../lib/buttons/ButtonPrimary";
+import { ButtonMono } from "../../lib/buttons/ButtonMono";
+import { ButtonMonoInvert } from "../../lib/buttons/ButtonMonoInvert";
+import { ButtonSecondary } from "../../lib/buttons/ButtonSecondary";
+import { ButtonInvert } from "../../lib/buttons/ButtonInvert";
+import { ButtonInvertRounded } from "../../lib/buttons/ButtonInvertRounded";
+import { ButtonText } from "../../lib/buttons/ButtonText";
+import { ButtonSubmit } from "../../lib/buttons/ButtonSubmit";
+import { ButtonHelp } from "../../lib/buttons/ButtonHelp";
+import { faUser } from "@fortawesome/free-solid-svg-icons";
+import {
+  faArrowAltCircleUp,
+  faUser as faUserReg,
+} from "@fortawesome/free-regular-svg-icons";
+
+export const Buttons = () => (
+  <>
+    <h4>Button Primary</h4>
+
+    <div className="row">
+      <ButtonPrimary text="Button" iconLeft={faUser} marginRight />
+      <ButtonPrimary
+        text="Button"
+        iconLeft={faUser}
+        marginRight
+        colorSecondary
+      />
+      <ButtonPrimary
+        text="Button"
+        iconLeft={faUser}
+        iconRight={faUser}
+        lg
+        marginRight
+      />
+      <ButtonPrimary text="Button" lg disabled />
+    </div>
+
+    <h4>Button Secondary</h4>
+    <div className="row">
+      <ButtonSecondary text="Button" marginRight />
+      <ButtonSecondary text="Button" iconLeft={faUser} marginRight />
+      <ButtonSecondary text="Button" iconRight={faUser} marginRight />
+      <ButtonSecondary
+        lg
+        text="Button"
+        iconLeft={faUser}
+        iconRight={faUser}
+        marginRight
+      />
+      <ButtonSecondary lg text="Button" disabled />
+    </div>
+
+    <h4>Button Mono</h4>
+    <div className="row">
+      <ButtonMono text="Button" marginRight />
+      <ButtonMono text="Button" iconLeft={faUser} marginRight />
+      <ButtonMono text="Button" iconRight={faUser} marginRight />
+      <ButtonMono
+        lg
+        text="Button"
+        iconLeft={faUser}
+        iconRight={faUser}
+        marginRight
+      />
+      <ButtonMono lg text="Button" disabled />
+    </div>
+
+    <h4>Button Mono Invert</h4>
+    <div className="row">
+      <ButtonMonoInvert text="Button" marginRight />
+      <ButtonMonoInvert text="Button" iconLeft={faUser} marginRight />
+      <ButtonMonoInvert text="Button" iconRight={faUser} marginRight />
+      <ButtonMonoInvert
+        lg
+        text="Button"
+        iconLeft={faUser}
+        iconRight={faUser}
+        marginRight
+      />
+      <ButtonMonoInvert lg text="Button" disabled />
+    </div>
+
+    <h4>Button Invert</h4>
+    <div className="row">
+      <ButtonInvert text="Button" marginRight />
+      <ButtonInvert text="Button" iconLeft={faUserReg} marginRight />
+      <ButtonInvert text="Button" iconRight={faUserReg} marginRight />
+      <ButtonInvert
+        text="Button"
+        iconLeft={faUserReg}
+        iconRight={faUserReg}
+        marginRight
+      />
+      <ButtonInvert text="Button" disabled />
+    </div>
+
+    <h4>Button Invert Rounded</h4>
+    <div className="row">
+      <ButtonInvertRounded text="Button" marginRight />
+      <ButtonInvertRounded text="Button" iconLeft={faUserReg} marginRight />
+      <ButtonInvertRounded text="Button" iconRight={faUserReg} marginRight />
+      <ButtonInvertRounded
+        lg
+        text="Button"
+        iconLeft={faUserReg}
+        iconRight={faUserReg}
+        marginRight
+      />
+      <ButtonInvertRounded lg text="Button" disabled />
+    </div>
+
+    <h4>Button Text</h4>
+    <div className="row">
+      <ButtonText text="Button" marginRight />
+      <ButtonText text="Button" iconLeft={faUserReg} marginRight />
+      <ButtonText text="Button" iconRight={faUserReg} marginRight />
+      <ButtonText
+        text="Button"
+        iconLeft={faUserReg}
+        iconRight={faUserReg}
+        marginRight
+      />
+      <ButtonText text="Button" disabled />
+    </div>
+
+    <h4>Button Submit</h4>
+    <div className="row">
+      <ButtonSubmit text="Button" marginRight />
+      <ButtonSubmit
+        text="Button"
+        iconLeft={faArrowAltCircleUp}
+        marginRight
+        colorSecondary
+      />
+      <ButtonSubmit text="Button" iconRight={faArrowAltCircleUp} marginRight />
+      <ButtonSubmit
+        text="Button"
+        iconLeft={faArrowAltCircleUp}
+        iconRight={faArrowAltCircleUp}
+        marginRight
+      />
+      <ButtonSubmit text="Button" disabled />
+    </div>
+    <h4>Button Help</h4>
+    <div className="row">
+      <ButtonHelp marginRight />
+      <ButtonHelp backgroundSecondary />
+    </div>
+  </>
+);

--- a/sandbox/components/index.tsx
+++ b/sandbox/components/index.tsx
@@ -1,0 +1,1 @@
+export { Buttons } from "./Buttons";

--- a/sandbox/components/index.tsx
+++ b/sandbox/components/index.tsx
@@ -1,1 +1,0 @@
-export { Buttons } from "./Buttons";

--- a/sandbox/sandbox.scss
+++ b/sandbox/sandbox.scss
@@ -37,7 +37,6 @@ main {
   z-index: 1;
   padding-left: 1.5rem;
 
-
   section {
     font-size: 1.05rem;
     margin: 1.25rem 0;

--- a/sandbox/sandbox.scss
+++ b/sandbox/sandbox.scss
@@ -8,7 +8,7 @@ main {
 
 .body {
   min-height: 100vh;
-  padding: 0 1.5rem;
+  padding: 1rem 1.5rem 0;
   width: 100%;
   max-width: 900px;
   margin: 0 0 0 15rem;

--- a/sandbox/sandbox.scss
+++ b/sandbox/sandbox.scss
@@ -5,16 +5,6 @@ main {
   background: var(--background-primary);
 }
 
-.header {
-  margin-bottom: 2rem;
-  padding: 0 1rem;
-  border: 1px solid var(--background-primary);
-
-  > h5 > button {
-    font-size: 0.92rem;
-  }
-}
-
 .body {
   min-height: 100vh;
   padding: 0 1.5rem;
@@ -26,6 +16,31 @@ main {
 .row {
   display: flex;
   margin-bottom: 1.25rem;
-  border-bottom: 1px solid var(--border-primary-color);
   padding-bottom: 1.5rem;
+}
+
+.sidenav {
+  height: 100%;
+  width: 10rem;
+  position: fixed;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  overflow-x: hidden;
+  background-color: var(--background-primary);
+  border-right: 1px solid var(--border-secondary-color);
+
+  > h5 > p {
+    padding-left: 1rem;
+    font-weight: bold;
+    font-size: 1.2rem;
+    text-decoration: none;
+    display: block;
+  }
+
+  > h5 > button {
+    padding-left: 2rem;
+    text-decoration: none;
+    display: block;
+  }
 }

--- a/sandbox/sandbox.scss
+++ b/sandbox/sandbox.scss
@@ -1,5 +1,6 @@
 /* Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 SPDX-License-Identifier: Apache-2.0 */
+@use "../styles/variables" as v;
 
 main {
   background: var(--background-primary);
@@ -10,7 +11,12 @@ main {
   padding: 0 1.5rem;
   width: 100%;
   max-width: 900px;
-  margin: 0 auto;
+  margin: 0 0 0 15rem;
+
+  /* We need the body not to over come sidebar */
+  @media (min-width: (v.$page-width-medium-threshold + 26px)) {
+    margin: 0 auto;
+  }
 }
 
 .row {

--- a/sandbox/sandbox.scss
+++ b/sandbox/sandbox.scss
@@ -3,7 +3,7 @@ SPDX-License-Identifier: Apache-2.0 */
 @use "../styles/variables" as v;
 
 main {
-  background: var(--background-primary);
+  background: var(--background-default);
 }
 
 .body {
@@ -25,28 +25,40 @@ main {
   padding-bottom: 1.5rem;
 }
 
-.sidenav {
-  height: 100%;
+.nav {
+  border-right: 1px solid var(--border-primary-color);
+  background-color: var(--background-primary);
   width: 10rem;
+  height: 100vh;
   position: fixed;
-  z-index: 1;
   top: 0;
   left: 0;
-  overflow-x: hidden;
-  background-color: var(--background-primary);
-  border-right: 1px solid var(--border-secondary-color);
+  overflow: auto;
+  z-index: 1;
+  padding-left: 1.5rem;
 
-  > h5 > p {
-    padding-left: 1rem;
-    font-weight: bold;
-    font-size: 1.2rem;
-    text-decoration: none;
-    display: block;
-  }
 
-  > h5 > button {
-    padding-left: 2rem;
-    text-decoration: none;
-    display: block;
+  section {
+    font-size: 1.05rem;
+    margin: 1.25rem 0;
+
+    h5 {
+      font-size: inherit;
+      font-weight: bold;
+      text-decoration: none;
+      display: block;
+      margin: 0.75rem 0;
+    }
+
+    > button {
+      font-size: inherit;
+      text-decoration: none;
+      display: block;
+      line-height: 2.25rem;
+
+      &.selected {
+        color: var(--network-color-primary);
+      }
+    }
   }
 }


### PR DESCRIPTION
The idea came, when I started to create more components;
In the "Sandbox" screen we will need to "list" the components that can be clicked and showcased (e.g. Buttons, Wrappers etc etc). In order to do that, in my opinion, the header should be moved to a sidebar, in order to exist enough space, to pick from a list to showcase in the main body of the screen;

The changes look like the following:
**Light Theme**:
![image](https://user-images.githubusercontent.com/5408605/228772818-febbab70-6779-4820-9f20-de3e37f9c0a9.png)

**Dark Theme**:
![image](https://user-images.githubusercontent.com/5408605/228772745-d5567b3a-8807-4750-8148-6ac5a8c41777.png)
