### PR TITLE
[WIP] Add config for vite aliases / support absolute paths

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,7 +54,16 @@
       "version": "detect"
     },
     "import/resolver": {
-      "typescript": {}
+      "typescript": {},
+      // alias must be also set in vite.config.ts
+      "alias": {
+        "map": [
+          ["@utils", "./lib/utils"],
+          ["@types", "./lib/types"],
+          ["@styles", "./styles"]
+        ],
+        "extensions": [".ts", ".js", ".jsx", ".json"]
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Update your [`dist.package.json`](https://github.com/paritytech/polkadot-dashboa
 yarn build
 ```
 
-
 #### Publish the package to NPM.
 
 ```
@@ -44,7 +43,7 @@ export const WrappedApp: React.FC = () => {
 
   // light, dark
   const { mode } = useTheme();
-  
+
   // polkadot, kusama, westend
   const { network } = useApi();
 
@@ -57,7 +56,8 @@ export const WrappedApp: React.FC = () => {
 ```
 
 #### 3. Import core components.
-Any [core component](https://github.com/paritytech/polkadot-dashboard-ui/tree/main/lib) can now be imported and used within the app. 
+
+Any [core component](https://github.com/paritytech/polkadot-dashboard-ui/tree/main/lib) can now be imported and used within the app.
 
 ## Package Testing in Local Development
 
@@ -116,7 +116,7 @@ Rules: {
 }
 ```
 
-#### 3. Ensure global imports are supported. 
+#### 3. Ensure global imports are supported.
 
 Polkadot staking dashboard uses [Vite.js](https://vitejs.dev) as its toolchain. Vite by default does not allow package imports from outside the project directory without explicitly allowing them. To allow global imports, simply turn off strict mode in `vite.config.js`
 

--- a/lib/buttons/ButtonHelp.tsx
+++ b/lib/buttons/ButtonHelp.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { InfoSVG } from "../svg/Info";
-import { ButtonCommonProps, ComponentBase } from "../types";
-import { valEmpty } from "../utils";
+import { ButtonCommonProps, ComponentBase } from "@types";
+import { valEmpty } from "@utils";
 
 export type ButtonHelpProps = ComponentBase &
   ButtonCommonProps & {

--- a/lib/buttons/ButtonInvert.tsx
+++ b/lib/buttons/ButtonInvert.tsx
@@ -1,9 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "../types";
+import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "@types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { valEmpty, valOr } from "../utils";
+import { valEmpty, valOr } from "@utils";
 import { motion } from "framer-motion";
 
 export type ButtonInvertProps = ComponentBase &

--- a/lib/buttons/ButtonInvertRounded.tsx
+++ b/lib/buttons/ButtonInvertRounded.tsx
@@ -1,9 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "../types";
+import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "@types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { valEmpty, valOr } from "../utils";
+import { valEmpty, valOr } from "@utils";
 
 export type ButtonInvertRoundedProps = ComponentBase &
   ButtonIconProps &

--- a/lib/buttons/ButtonMono.tsx
+++ b/lib/buttons/ButtonMono.tsx
@@ -1,9 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "../types";
+import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "@types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { valEmpty, valOr } from "../utils";
+import { valEmpty, valOr } from "@utils";
 import { motion } from "framer-motion";
 
 export type ButtonMonoProps = ComponentBase &

--- a/lib/buttons/ButtonMonoInvert.tsx
+++ b/lib/buttons/ButtonMonoInvert.tsx
@@ -1,9 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "../types";
+import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "@types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { valEmpty, valOr } from "../utils";
+import { valEmpty, valOr } from "@utils";
 import { motion } from "framer-motion";
 
 export type ButtonMonoProps = ComponentBase &

--- a/lib/buttons/ButtonPrimary.tsx
+++ b/lib/buttons/ButtonPrimary.tsx
@@ -1,9 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "../types";
+import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "@types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { valEmpty, valOr } from "../utils";
+import { valEmpty, valOr } from "@utils";
 import { motion } from "framer-motion";
 
 export type ButtonPrimaryProps = ComponentBase &

--- a/lib/buttons/ButtonSecondary.tsx
+++ b/lib/buttons/ButtonSecondary.tsx
@@ -1,9 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "../types";
+import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "@types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { valEmpty, valOr } from "../utils";
+import { valEmpty, valOr } from "@utils";
 
 export type ButtonSecondaryProps = ComponentBase &
   ButtonIconProps &

--- a/lib/buttons/ButtonSubmit.tsx
+++ b/lib/buttons/ButtonSubmit.tsx
@@ -1,9 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "../types";
+import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "@types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { valEmpty, valOr } from "../utils";
+import { valEmpty, valOr } from "@utils";
 import { motion } from "framer-motion";
 
 export type ButtonSubmitProps = ComponentBase &

--- a/lib/buttons/ButtonText.tsx
+++ b/lib/buttons/ButtonText.tsx
@@ -1,9 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "../types";
+import { ButtonIconProps, ButtonCommonProps, ComponentBase } from "@types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { valEmpty, valOr } from "../utils";
+import { valEmpty, valOr } from "@utils";
 import { motion } from "framer-motion";
 
 export type ButtonMonoProps = ComponentBase &

--- a/lib/buttons/index.tsx
+++ b/lib/buttons/index.tsx
@@ -1,0 +1,9 @@
+export { ButtonPrimary } from "./ButtonPrimary";
+export { ButtonMono } from "./ButtonMono";
+export { ButtonMonoInvert } from "./ButtonMonoInvert";
+export { ButtonSecondary } from "./ButtonSecondary";
+export { ButtonInvert } from "./ButtonInvert";
+export { ButtonInvertRounded } from "./ButtonInvertRounded";
+export { ButtonText } from "./ButtonText";
+export { ButtonSubmit } from "./ButtonSubmit";
+export { ButtonHelp } from "./ButtonHelp";

--- a/lib/core/index.tsx
+++ b/lib/core/index.tsx
@@ -1,11 +1,11 @@
 // Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ComponentBase } from "../types";
+import { ComponentBase } from "@types";
 import { RefObject, forwardRef } from "react";
 import { motion } from "framer-motion";
 
-import { valEmpty } from "../utils";
+import { valEmpty } from "@utils";
 import { EntryProps, SideProps } from "./types";
 /* Entry
  *

--- a/lib/core/types.ts
+++ b/lib/core/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ComponentBase, Network, ThemeMode } from "../types";
+import { ComponentBase, Network, ThemeMode } from "@types";
 
 export type EntryProps = ComponentBase & {
   // the theme mode

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import "../styles/index.scss";
+import "@styles/index.scss";
 
 // Core
 export * from "./core";

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint": "^8.37.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.8.0",
+    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-typescript": "^3.5.4",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsx-a11y": "^6.6.1",

--- a/sandbox/App.tsx
+++ b/sandbox/App.tsx
@@ -2,15 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from "react";
-import { ButtonPrimary } from "@lib/buttons/ButtonPrimary";
-import { ButtonMono } from "@lib/buttons/ButtonMono";
-import { ButtonMonoInvert } from "@lib/buttons/ButtonMonoInvert";
-import { ButtonSecondary } from "@lib/buttons/ButtonSecondary";
-import { ButtonInvert } from "@lib/buttons/ButtonInvert";
-import { ButtonInvertRounded } from "@lib/buttons/ButtonInvertRounded";
-import { ButtonText } from "@lib/buttons/ButtonText";
-import { ButtonSubmit } from "@lib/buttons/ButtonSubmit";
-import { ButtonHelp } from "@lib/buttons/ButtonHelp";
+import {
+  ButtonPrimary,
+  ButtonMono,
+  ButtonMonoInvert,
+  ButtonSecondary,
+  ButtonInvert,
+  ButtonInvertRounded,
+  ButtonText,
+  ButtonSubmit,
+  ButtonHelp,
+  // eslint-disable-next-line import/no-unresolved
+} from "@lib/buttons";
 import { faUser } from "@fortawesome/free-solid-svg-icons";
 import {
   faArrowAltCircleUp,

--- a/sandbox/App.tsx
+++ b/sandbox/App.tsx
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from "react";
-import { ButtonPrimary } from "../lib/buttons/ButtonPrimary";
-import { ButtonMono } from "../lib/buttons/ButtonMono";
-import { ButtonMonoInvert } from "../lib/buttons/ButtonMonoInvert";
-import { ButtonSecondary } from "../lib/buttons/ButtonSecondary";
-import { ButtonInvert } from "../lib/buttons/ButtonInvert";
-import { ButtonInvertRounded } from "../lib/buttons/ButtonInvertRounded";
-import { ButtonText } from "../lib/buttons/ButtonText";
-import { ButtonSubmit } from "../lib/buttons/ButtonSubmit";
-import { ButtonHelp } from "../lib/buttons/ButtonHelp";
+import { ButtonPrimary } from "@lib/buttons/ButtonPrimary";
+import { ButtonMono } from "@lib/buttons/ButtonMono";
+import { ButtonMonoInvert } from "@lib/buttons/ButtonMonoInvert";
+import { ButtonSecondary } from "@lib/buttons/ButtonSecondary";
+import { ButtonInvert } from "@lib/buttons/ButtonInvert";
+import { ButtonInvertRounded } from "@lib/buttons/ButtonInvertRounded";
+import { ButtonText } from "@lib/buttons/ButtonText";
+import { ButtonSubmit } from "@lib/buttons/ButtonSubmit";
+import { ButtonHelp } from "@lib/buttons/ButtonHelp";
 import { faUser } from "@fortawesome/free-solid-svg-icons";
 import {
   faArrowAltCircleUp,

--- a/sandbox/styles.scss
+++ b/sandbox/styles.scss
@@ -1,7 +1,7 @@
 /* Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 SPDX-License-Identifier: Apache-2.0 */
 
-@import "../styles/index";
+@import "@styles/index";
 @import "./sandbox";
 
 html {

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -1,10 +1,8 @@
 /* Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 SPDX-License-Identifier: Apache-2.0 */
 
-
 $page-width-small-threshold: 850px;
 $page-width-medium-threshold: 1175px;
 $page-max-width: 1550px;
-
 $side-menu-minimised-width: 75px;
 $side-menu-maximised-width: 185px;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,8 +15,8 @@ export default defineConfig({
   resolve: {
     alias: [
       { find: "@lib", replacement: path.resolve(__dirname, "lib") },
-      { find: "@types", replacement: path.resolve(__dirname, "types") },
-      { find: "@utils", replacement: path.resolve(__dirname, "utils") },
+      { find: "@types", replacement: path.resolve(__dirname, "lib/types") },
+      { find: "@utils", replacement: path.resolve(__dirname, "lib/utils") },
       { find: "@styles", replacement: path.resolve(__dirname, "styles") },
     ],
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@
 
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import * as path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,4 +12,12 @@ export default defineConfig({
     port: 5174,
   },
   plugins: [react()],
+  resolve: {
+    alias: [
+      { find: "@lib", replacement: path.resolve(__dirname, "lib") },
+      { find: "@types", replacement: path.resolve(__dirname, "types") },
+      { find: "@utils", replacement: path.resolve(__dirname, "utils") },
+      { find: "@styles", replacement: path.resolve(__dirname, "styles") },
+    ],
+  },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   },
   plugins: [react()],
   resolve: {
+    // alias must be also set in .eslintrc.json
     alias: [
       { find: "@lib", replacement: path.resolve(__dirname, "lib") },
       { find: "@types", replacement: path.resolve(__dirname, "lib/types") },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,6 +1441,11 @@ eslint-config-prettier@^8.8.0:
   resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz#bfda738d412adc917fd7b038857110efe98c9348"
   integrity sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==
 
+eslint-import-resolver-alias@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz#297062890e31e4d6651eb5eba9534e1f6e68fc97"
+  integrity sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==
+
 eslint-import-resolver-node@^0.3.7:
   version "0.3.7"
   resolved "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz#83b375187d412324a1963d84fa664377a23eb4d7"


### PR DESCRIPTION
This PR adds aliases for imports in order to avoid relative paths;
E.g. instead of:
```tsx
import { valEmpty } from "../utils";
```
now one can just use:
```tsx
import { valEmpty } from "@utils";
```

with the respective configuration in VITE:
```tsx
alias: [
      { find: "@utils", replacement: path.resolve(__dirname, "lib/utils") },
    ],
 ```
 
 This PR also introduces alias checks for eslint