### PR TITLE
Add publish automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,12 +17,12 @@ jobs:
         run: yarn build
       - name: Check if 'core-ui' version has been updated
         id: core_ui_version
-        uses: PostHog/check-package-version@v2
+        uses: PostHog/check-package-version@v2.0.0
         with:
           path: "./packages/core-ui"
       - name: Check if 'utils' version has been updated
         id: utils_version
-        uses: PostHog/check-package-version@v2
+        uses: PostHog/check-package-version@v2.0.0
         with:
           path: "./packages/core-ui"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish
+
+on:
+  push:
+    branches: [nik-add-publish-automation]
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.0
+      - run: yarn install
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Build NPM Package
+        run: yarn build
+      - name: Check if 'core-ui' version has been updated
+        id: core_ui_version
+        uses: PostHog/check-package-version@v2
+        with:
+          path: "./packages/core-ui"
+      - name: Check if 'utils' version has been updated
+        id: utils_version
+        uses: PostHog/check-package-version@v2
+        with:
+          path: "./packages/core-ui"
+
+      - name: Publish Dry Run Core UI
+        working-directory: "./packages/core-ui"
+        run: npm publish --unsafe-perm --dry-run
+      - name: Publish core-ui to npm
+        if: steps.core_ui_version.outputs.committed-version > steps.core_ui_version.outputs.published-version
+        id: publish
+        uses: JS-DevTools/npm-publish@v1
+        # Warning: this GitHub action doesn't seem to run prepublish scripts, hence
+        # the `npm publish --dry-run` done right above is important to ensure this.
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./packages/core-ui/package.json
+          access: public
+      - name: Publish Dry Run Utils
+        working-directory: "./packages/utils"
+        run: npm publish --unsafe-perm --dry-run
+      - name: Publish utils to npm
+        if: steps.utils_version.outputs.committed-version > steps.utils_version.outputs.published-version
+        id: publish
+        uses: JS-DevTools/npm-publish@v1
+        # Warning: this GitHub action doesn't seem to run prepublish scripts, hence
+        # the `npm publish --dry-run` done right above is important to ensure this.
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./packages/utils/package.json
+          access: public
+
+  all:
+    # This dummy job depends on all the mandatory checks. It succeeds if and only if all CI checks
+    # are successful.
+    needs: [npm-publish]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo Success


### PR DESCRIPTION
Add publish automation for `core-ui` and `utils` packages;

In this automation there are checks for core-ui and utils packages - if the version of the package has changed.
If not then there is no publish happening - if there is, then automatically the new version should be deployed in NPMJS;