### PR TITLE
Expand global styles in core-ui

### DIFF
--- a/packages/core-ui/dist.package.json
+++ b/packages/core-ui/dist.package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadotcloud/core-ui",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "license": "Apache-2.0",
   "types": "index.d.ts",
   "peerDependencies": {

--- a/packages/core-ui/package.json
+++ b/packages/core-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadotcloud/core-ui",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "license": "Apache-2.0",
   "author": "Ross Bulat",
   "description": "Core UI Components for Polkadot Dashboards.",

--- a/packages/core-ui/styles/core.scss
+++ b/packages/core-ui/styles/core.scss
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0 */
   width: 100%;
   background-attachment: fixed;
   display: flex;
-  flex-flow: column nowrap;
+  flex-direction: column;
   min-height: 100vh;
   flex-grow: 1;
 
@@ -158,14 +158,6 @@ SPDX-License-Identifier: Apache-2.0 */
   &.no-vertical-margin {
     margin-top: 0;
     margin-bottom: 0;
-  }
-
-  /* kill heading padding, already applied to wrapper */
-  h1,
-  h2,
-  h3,
-  h4 {
-    margin-top: 0;
   }
 }
 

--- a/packages/core-ui/styles/global.scss
+++ b/packages/core-ui/styles/global.scss
@@ -1,0 +1,17 @@
+/* @license Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
+SPDX-License-Identifier: Apache-2.0 */
+
+/* Every element conforms to border-box by default. */
+* {
+  box-sizing: border-box;
+}
+
+/* Define default body style and cancel out spacing. */
+body {
+  margin: 0;
+  font-family: Inter, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
+  font-variation-settings: "wght" 500;
+}

--- a/packages/core-ui/styles/global.scss
+++ b/packages/core-ui/styles/global.scss
@@ -8,10 +8,88 @@ SPDX-License-Identifier: Apache-2.0 */
 
 /* Define default body style and cancel out spacing. */
 body {
-  margin: 0;
-  font-family: Inter, sans-serif;
+  font-family: 'Inter', 'sans-serif', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden;
-  font-variation-settings: "wght" 500;
+  font-weight: 500;
+  font-variation-settings: 'wght' 500;
+  margin: 0;
+}
+
+/* Define default header tag styling. */
+h1 {
+  font-weight: normal;
+  font-size: 1.6rem;
+  line-height: 1.6rem;
+  font-weight: 600;
+  font-variation-settings: 'wght' 600;
+  margin: 0;
+}
+
+h2 {
+  font-weight: normal;
+  font-size: 1.4rem;
+  line-height: 1.6rem;
+  font-weight: 600;
+  font-variation-settings: 'wght' 650;
+  margin: 0;
+}
+
+h3 {
+  font-weight: normal;
+  font-size: 1.25rem;
+  line-height: 1.55rem;
+  font-weight: 500;
+  font-variation-settings: 'wght' 560;
+  margin: 0;
+}
+
+h4 {
+  font-weight: normal;
+  font-size: 1.08rem;
+  line-height: 1.65rem;
+  font-weight: 500;
+  font-variation-settings: 'wght' 500;
+  margin: 0;
+}
+
+h5 {
+  font-weight: normal;
+  font-size: 0.92rem;
+  line-height: 1.02rem;
+  font-weight: 500;
+  font-variation-settings: 'wght' 540;
+  margin: 0;
+}
+
+/* Define default paragraph styling. */
+p {
+  font-size: 0.98rem;
+  line-height: 1.5rem;
+  margin: 0.75rem 0;
+}
+
+/* Define default anchor style. */
+a {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+/* Define bare-bones button style. */
+button {
+  font-family: 'Inter', sans-serif;
+  font-weight: normal;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  font-variation-settings: 'wght' 600;
+  margin: 0;
+  padding: 0;
+}
+
+/* Define default input style. */
+input {
+  font-family: 'Inter', sans-serif;
 }

--- a/packages/core-ui/styles/global.scss
+++ b/packages/core-ui/styles/global.scss
@@ -63,7 +63,7 @@ h5 {
   margin: 0;
 }
 
-/* Define default paragraph styling. */
+/* Define default paragraph style. */
 p {
   font-size: 0.98rem;
   line-height: 1.5rem;

--- a/packages/core-ui/styles/index.scss
+++ b/packages/core-ui/styles/index.scss
@@ -1,6 +1,18 @@
 /* @license Copyright 2023 @paritytech/polkadot-dashboard-ui authors & contributors
 SPDX-License-Identifier: Apache-2.0 */
 
+/* Developer Notes:
+ * This file is the entry point to which all of core-ui styles are built.
+ * Additional files imported here will be a part of the final bundle. */
+
+ /* Global styling. */
+ @use "global";
+
+/* UI theme variables. */
 @use "theme";
+
+/* Core wrappers, tag styles and structural component styles. */
 @use "core";
+
+/* Button component styles. */
 @use "buttons";

--- a/sandbox/src/styles/index.scss
+++ b/sandbox/src/styles/index.scss
@@ -5,23 +5,9 @@ SPDX-License-Identifier: Apache-2.0 */
 
 html {
   font-size: 10px;
-
   @media (min-width: 600px) {
     font-size: 11.2px;
   }
-}
-
-body {
-  margin: 0;
-  font-family: Inter, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  overflow-x: hidden;
-  font-variation-settings: "wght" 500;
-}
-
-* {
-  box-sizing: border-box;
 }
 
 h1 {


### PR DESCRIPTION
Adds default styling to global HTML tags, including headers, anchor, paragraph, and bare-bones button & input styles.